### PR TITLE
trigger e2e tests only on PRs

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -1,15 +1,15 @@
 name: PR e2e Tests
 
 on:
-  workflow_run:
-    workflows: ["dev-workflow"]
-    types: [completed]
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   trigger-e2e-tests:
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:

--- a/scripts/e2e-trigger.sh
+++ b/scripts/e2e-trigger.sh
@@ -8,8 +8,14 @@ if [[ "${CI}" != "true" ]]; then
     exit 1
 fi
 
+if [[ -n "${GITHUB_HEAD_REF}" ]]; then
+    TEST_NLK_CHART_REF="${GITHUB_HEAD_REF}"
+else
+    TEST_NLK_CHART_REF="${GITHUB_REF_NAME}"
+fi
+
+TEST_NLK_CHART_URL="oci://${DOCKER_REGISTRY_PROD}/nginx-azure-lb/nginxaas-loadbalancer-kubernetes/charts/${TEST_NLK_CHART_REF}/nginxaas-loadbalancer-kubernetes"
 TEST_NLK_IMG_TAG=$(cat version)
-TEST_NLK_CHART_URL="oci://${DOCKER_REGISTRY_PROD}/nginx-azure-lb/nginxaas-loadbalancer-kubernetes/charts/${GITHUB_REF_NAME}/nginxaas-loadbalancer-kubernetes"
 GITLAB_API="${GITLAB_API_URL:-https://gitlab.com/api/v4}"
 
 GITLAB_PIPELINE_ID=$(curl -sS --fail-with-body -X POST \


### PR DESCRIPTION
e2e trigger will only run when a PR is
in one of these states:
- opened
- reopened
- synchronize
- ready_for_review (out of draft)