### PR TITLE
Fail pipline on critical security issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Security
+
+- Fail CI pipeline when Trivy detects HIGH or CRITICAL vulnerabilities in container images
+
 ## 1.0.0 (Month Date, Year)
 
 Initial release of the NGINX template repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Security
-
-- Fail CI pipeline when Trivy detects HIGH or CRITICAL vulnerabilities in container images
-
 ## 1.0.0 (Month Date, Year)
 
 Initial release of the NGINX template repository.

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ scan-container-image:
 	@$(MAKE) .run DOCKER_EXTRA_ARGS=" \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		--group-add $(shell stat -c '%g' /var/run/docker.sock)" \
-		args="trivy image nginxaas-loadbalancer-kubernetes:current"
+		args="trivy image --severity HIGH,CRITICAL --exit-code 1 nginxaas-loadbalancer-kubernetes:current"
 	@$(MAKE) .run DOCKER_EXTRA_ARGS=" \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		--group-add $(shell stat -c '%g' /var/run/docker.sock)" \


### PR DESCRIPTION
### Proposed changes

Fail the CI pipeline when Trivy detects HIGH or CRITICAL security vulnerabilities in container images.

Added `--exit-code 1` flag to the Trivy scan command in the Makefile to ensure builds with critical security issues cannot proceed.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/nginx-loadbalancer-kubernetes/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/nginx-loadbalancer-kubernetes/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/nginx-loadbalancer-kubernetes/blob/main/CHANGELOG.md))
